### PR TITLE
Eguma/#20 create security groups for alb, ecs and aurora

### DIFF
--- a/infra/application/aws/data.tf
+++ b/infra/application/aws/data.tf
@@ -1,3 +1,22 @@
-data "aws_vpc" "main" {
-  id = var.main_vpc_id
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+# Read the platform stack outputs (VPC, subnets, ECR) instead of passing them in.
+data "terraform_remote_state" "platform" {
+  backend   = "s3"
+  workspace = terraform.workspace
+
+  config = {
+    bucket = "hello-springboot-tfstate"
+    key    = "aws/platform"
+    region = "ap-northeast-1"
+  }
+}
+
+locals {
+  vpc_id             = data.terraform_remote_state.platform.outputs.vpc_id
+  public_subnet_ids  = data.terraform_remote_state.platform.outputs.public_subnet_ids
+  private_subnet_ids = data.terraform_remote_state.platform.outputs.private_subnet_ids
+  ecr_repository_url = data.terraform_remote_state.platform.outputs.ecr_repository_url
 }

--- a/infra/application/aws/main.tf
+++ b/infra/application/aws/main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "hello-springboot-tfstate"
-    key    = "aws/platform"
+    key    = "aws/application"
     region = "ap-northeast-1"
   }
 }

--- a/infra/application/aws/security_group.tf
+++ b/infra/application/aws/security_group.tf
@@ -1,9 +1,80 @@
-resource "aws_security_group" "hello_spring_boot" {
-  name        = "hello spring boot"
-  description = "Security group for ECS service, hello spring boot"
-  vpc_id      = data.aws_vpc.main.id
+# ALB: accepts HTTP from the internet.
+resource "aws_security_group" "alb" {
+  name        = "${var.app_name}-alb"
+  description = "Security group for the ${var.app_name} ALB"
+  vpc_id      = local.vpc_id
 
   tags = {
-    Name = "ecs-security-group"
+    Name = "${var.app_name}-alb"
   }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http" {
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTP from the internet"
+  ip_protocol       = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_all" {
+  security_group_id = aws_security_group.alb.id
+  description       = "Allow all outbound"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+# ECS tasks: only reachable from the ALB on the container port.
+resource "aws_security_group" "ecs" {
+  name        = "${var.app_name}-ecs"
+  description = "Security group for the ${var.app_name} ECS service"
+  vpc_id      = local.vpc_id
+
+  tags = {
+    Name = "${var.app_name}-ecs"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ecs_from_alb" {
+  security_group_id            = aws_security_group.ecs.id
+  description                  = "Container port from the ALB"
+  ip_protocol                  = "tcp"
+  from_port                    = var.container_port
+  to_port                      = var.container_port
+  referenced_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "ecs_all" {
+  security_group_id = aws_security_group.ecs.id
+  description       = "Allow all outbound (ECR, Secrets Manager, Aurora)"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+# Aurora: only reachable from the ECS tasks on the MySQL port.
+resource "aws_security_group" "aurora" {
+  name        = "${var.app_name}-aurora"
+  description = "Security group for the ${var.app_name} Aurora cluster"
+  vpc_id      = local.vpc_id
+
+  tags = {
+    Name = "${var.app_name}-aurora"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "aurora_from_ecs" {
+  security_group_id            = aws_security_group.aurora.id
+  description                  = "MySQL from the ECS service"
+  ip_protocol                  = "tcp"
+  from_port                    = 3306
+  to_port                      = 3306
+  referenced_security_group_id = aws_security_group.ecs.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "aurora_all" {
+  security_group_id = aws_security_group.aurora.id
+  description       = "Allow all outbound"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
 }

--- a/infra/application/aws/variables.tf
+++ b/infra/application/aws/variables.tf
@@ -1,3 +1,9 @@
-variable "main_vpc_id" {
-  type = string
+variable "app_name" {
+  type    = string
+  default = "hello-spring-boot"
+}
+
+variable "container_port" {
+  type    = number
+  default = 8080
 }


### PR DESCRIPTION
## Summary
- Replace the placeholder ECS security group with three tiered security groups:
  - **alb**: HTTP (80) from the internet
  - **ecs**: container port (8080) from the ALB only
  - **aurora**: MySQL (3306) from the ECS tasks only
- Wire the application stack to the platform stack via `terraform_remote_state` (VPC / subnets / ECR), replacing the `main_vpc_id` variable
- Fix the application backend `key` (`aws/platform` -> `aws/application`) so it no longer collides with the platform state

## Depends on
- #31 (platform outputs consumed via `terraform_remote_state`)

Closes #20
Part of #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)