### PR TITLE
Replace deprecated openjdk base image with eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- `openjdk:17-jdk-slim` was removed from Docker Hub (the `openjdk` official image is deprecated), so `docker build` fails with `manifest unknown`
- Switch the base image to the maintained **`eclipse-temurin:17-jre-jammy`** (JRE is enough to run the Spring Boot jar)

## Context
Found while building/pushing the application image for the ECS dev environment (#4 / #30). The pushed image is already running healthily behind the ALB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)