### PR TITLE
Eguma/#38 set jooq sql dialect to mysql

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,5 @@ spring:
     username: hellouser
     password: hellopassword
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jooq:
+    sql-dialect: MYSQL


### PR DESCRIPTION
## Summary
- `GET /user` returned 500 (`SQLSyntaxErrorException`) because jOOQ rendered identifiers with double quotes (`"hellodb"."users"."id"`), i.e. the runtime `SQLDialect` resolved to `DEFAULT`
- Set `spring.jooq.sql-dialect: MYSQL` so generated SQL uses backtick quoting

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)