### PR TITLE
Eguma/#39 run flyway migrations on application startup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-jooq")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
 


### PR DESCRIPTION
## Summary
- Flyway only ran as a build-time Gradle plugin, so the `users` table was never created in the deployed Aurora database
- Add runtime `flyway-core` / `flyway-mysql` dependencies so Spring Boot auto-applies `src/main/resources/db/migration` on startup (local MySQL and Aurora alike)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)