### PR TITLE
Eguma/#42 add deploy & teardown scripts for the dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+## Local development
 
 ```bash
 $ docker compose up -d
@@ -13,4 +13,24 @@ $ ./gradlew flywayMigrate
 
 $ # Generate Code
 $ ./gradlew generateHellodbJooq
+```
+
+## Dev environment on AWS (ECS + ALB + Aurora MySQL)
+
+The full dev environment can be deployed / torn down with one command each.
+
+Prerequisites:
+- AWS profile `sandbox` is valid (AssumeRole into the SANDBOX-SAMPLE account). See `scripts/lib.sh` for the defaults you can override (`AWS_PROFILE`, `REGION`, `WORKSPACE`).
+- Docker daemon running (for `deploy.sh`, which builds & pushes the image).
+
+```bash
+$ ./scripts/deploy.sh     # platform -> build & push image -> application, prints the ALB URL
+$ ./scripts/teardown.sh   # destroys everything to stop charges
+```
+
+After `deploy.sh` finishes (ECS rollout / Aurora take a few minutes to be healthy):
+
+```bash
+$ curl http://<alb-dns>/        # -> Hello World!
+$ curl http://<alb-dns>/user    # -> [] (reads the Aurora users table)
 ```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Deploy the whole dev environment (ECS + ALB + Aurora MySQL) in one command:
+#   platform -> build jar -> build & push image -> application -> smoke test
+#
+# Prerequisites:
+#   - AWS profile 'sandbox' valid (AssumeRole into the SANDBOX-SAMPLE account)
+#   - Docker daemon running
+#
+# Usage: ./scripts/deploy.sh
+#
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require_aws
+require_docker
+
+# 1. platform (VPC, subnets, NAT, ECR, outputs)
+log "Applying platform stack"
+tf_init_ws "$PLATFORM_DIR"
+tf "$PLATFORM_DIR" apply -auto-approve -input=false
+
+ECR_URL="$(tf "$PLATFORM_DIR" output -raw ecr_repository_url)"
+REGISTRY="${ECR_URL%/*}"
+
+# 2. build the application jar (jOOQ sources are committed, so no DB is needed)
+log "Building application jar"
+( cd "$ROOT" && ./gradlew bootJar --console=plain )
+
+# 3. build & push the container image for Fargate (linux/amd64)
+log "Building & pushing image to $ECR_URL:latest"
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$REGISTRY"
+docker build --platform linux/amd64 -t "$ECR_URL:latest" "$ROOT"
+docker push "$ECR_URL:latest"
+
+# 4. application (Aurora, ALB, ECS, IAM, secrets, logs)
+log "Applying application stack"
+tf_init_ws "$APP_DIR"
+tf "$APP_DIR" apply -auto-approve -input=false
+
+# 5. roll the service so it pulls the freshly pushed :latest (no-op on first apply)
+aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" \
+  --force-new-deployment --region "$REGION" >/dev/null 2>&1 || true
+
+DNS="$(tf "$APP_DIR" output -raw alb_dns_name)"
+log "Deployed. ALB endpoint:"
+echo "    curl http://$DNS/        # -> Hello World!"
+echo "    curl http://$DNS/user    # -> [] (reads the Aurora users table)"
+echo
+echo "Note: the ECS rollout / Aurora may take a few minutes to become healthy."

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Shared configuration and helpers for the dev-environment scripts.
+set -euo pipefail
+
+# --- configuration (override via environment if needed) -----------------------
+export AWS_PROFILE="${AWS_PROFILE:-sandbox}"
+REGION="${REGION:-ap-northeast-1}"
+WORKSPACE="${WORKSPACE:-dev}"
+ECR_REPO="${ECR_REPO:-hello-spring-boot}"
+CLUSTER="${CLUSTER:-hello-spring-boot}"
+SERVICE="${SERVICE:-hello-spring-boot}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM_DIR="$ROOT/infra/platform/aws"
+APP_DIR="$ROOT/infra/application/aws"
+
+# --- helpers ------------------------------------------------------------------
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+# terraform wrapper bound to a stack directory + the dev workspace
+tf() {
+  local dir="$1"
+  shift
+  terraform -chdir="$dir" "$@"
+}
+
+tf_init_ws() {
+  local dir="$1"
+  tf "$dir" init -input=false >/dev/null
+  tf "$dir" workspace select "$WORKSPACE" 2>/dev/null \
+    || tf "$dir" workspace new "$WORKSPACE"
+}
+
+require_aws() {
+  local acct
+  acct="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)" || {
+    echo "ERROR: AWS credentials for profile '$AWS_PROFILE' are not valid." >&2
+    echo "       Check '~/.aws/config' (expected the 'sandbox' AssumeRole profile)." >&2
+    exit 1
+  }
+  log "AWS profile '$AWS_PROFILE' -> account $acct, region $REGION, workspace $WORKSPACE"
+}
+
+require_docker() {
+  docker info >/dev/null 2>&1 || {
+    echo "ERROR: Docker daemon is not running (needed to build/push the image)." >&2
+    exit 1
+  }
+}

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Tear down the whole dev environment to stop charges:
+#   application (ALB, Aurora, ECS) -> delete ECR images -> platform (NAT, VPC, ECR)
+#
+# Prerequisites:
+#   - AWS profile 'sandbox' valid (AssumeRole into the SANDBOX-SAMPLE account)
+#
+# Usage: ./scripts/teardown.sh
+#
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+require_aws
+
+# 1. application stack first (it depends on the platform outputs)
+log "Destroying application stack"
+tf_init_ws "$APP_DIR"
+tf "$APP_DIR" destroy -auto-approve -input=false
+
+# 2. empty the ECR repository so the platform destroy can remove it
+log "Deleting ECR images"
+IMAGE_IDS="$(aws ecr list-images --repository-name "$ECR_REPO" --region "$REGION" \
+  --query 'imageIds[*]' --output json 2>/dev/null || echo '[]')"
+if [ "$IMAGE_IDS" != "[]" ] && [ -n "$IMAGE_IDS" ]; then
+  aws ecr batch-delete-image --repository-name "$ECR_REPO" --region "$REGION" \
+    --image-ids "$IMAGE_IDS" >/dev/null && echo "    images deleted"
+else
+  echo "    no images to delete"
+fi
+
+# 3. platform stack
+log "Destroying platform stack"
+tf_init_ws "$PLATFORM_DIR"
+tf "$PLATFORM_DIR" destroy -auto-approve -input=false
+
+log "Teardown complete. All billable resources removed."


### PR DESCRIPTION
## Summary
- Add `scripts/deploy.sh`: platform apply -> build jar -> build & push image -> application apply -> prints the ALB URL
- Add `scripts/teardown.sh`: application destroy -> delete ECR images -> platform destroy
- Add `scripts/lib.sh`: shared config (`AWS_PROFILE=sandbox`, region, `dev` workspace) and helpers, with preflight checks for AWS creds / Docker
- Document usage and prerequisites in the README

## Notes
- Defaults target the SANDBOX-SAMPLE account via the `sandbox` AssumeRole profile; override with env vars (`AWS_PROFILE`, `REGION`, `WORKSPACE`).
- Verified with `bash -n`. The underlying flow matches the manual deploy/teardown already run successfully.

Closes #42
Part of #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)