### PR TITLE
eguma/#44 upgrade JVM to Java 21 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /app
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,5 +105,5 @@ tasks.test {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Feb 05 17:33:29 JST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 概要
JVM を Java 17 → Java 21 (LTS) に引き上げる。

Closes #44

## 変更内容
- \`build.gradle.kts\`: \`jvmToolchain(17)\` → \`jvmToolchain(21)\`
- \`Dockerfile\`: \`eclipse-temurin:17-jre-jammy\` → \`21-jre-jammy\`
- \`gradle/wrapper/gradle-wrapper.properties\`: Gradle \`8.4\` → \`8.10.2\`（Java 21 ツールチェーン完全対応）

## 確認
- \`./gradlew build\`（detekt 含む） → BUILD SUCCESSFUL
- foojay リゾルバ設定済みのため JDK 21 は Gradle が自動取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)